### PR TITLE
Permit to directly pass a Doctrine Query object to the builder

### DIFF
--- a/Chart/Builder.php
+++ b/Chart/Builder.php
@@ -30,7 +30,12 @@ class Builder extends AbstractBuilder
     }
     
     public function query($query) {
-        $this->q = $this->em->createQuery($query);
+        if($query instanceof Query) {
+            $this->q = $query;
+        } else {
+            $this->q = $this->em->createQuery($query);
+        }
+        
         return $this;
     }
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ class AppController extends Controller{
     }
 }
 ```
+You can also pass a Doctrine\ORM\Query object instead of a DQL query.
+This allow you to use a repository to store your charts queries.
+
 Please, see the [mukadi/chartjs-builder documentation](https://github.com/mbo2olivier/mukadi-chartjs-builder) if you want to learn more about chart construction.
 
 ## Render chart in twig template


### PR DESCRIPTION
With this PR you can directly pass a Doctrine\ORM\Query object to the builder.
So you can use a repository to store all your queries in one place.